### PR TITLE
add label and size to scatter3

### DIFF
--- a/src/main/scala/org/viz/lightning/types/Three.scala
+++ b/src/main/scala/org/viz/lightning/types/Three.scala
@@ -4,9 +4,20 @@ import org.viz.lightning.Visualization
 
 trait Three extends Base {
 
-  def scatter3(x: Array[Double], y: Array[Double], z: Array[Double]): Visualization = {
+  def scatter3(x: Array[Double],
+      y: Array[Double],
+      z: Array[Double],
+      label: Array[Int] = Array[Int]()
+      size: Array[Int] = Array[Int]()): Visualization = {
     val out = (x, y, z).zipped.map((x, y, z) => List(x, y, z)).toList
-    val payload = Map("points" -> out)
+    var payload = Map[String, Any]()
+    payload += "points" -> out
+    if (label.length > 0) {
+      payload += "label" -> label.toList
+    }
+    if (size.length > 0) {
+      payload += "size" -> size.toList
+    }
     plot("scatter3", payload)
   }
 

--- a/src/main/scala/org/viz/lightning/types/Three.scala
+++ b/src/main/scala/org/viz/lightning/types/Three.scala
@@ -8,7 +8,7 @@ trait Three extends Base {
       y: Array[Double],
       z: Array[Double],
       label: Array[Int] = Array[Int]()
-      size: Array[Int] = Array[Int]()): Visualization = {
+      size: Array[Double] = Array[Double]()): Visualization = {
     val out = (x, y, z).zipped.map((x, y, z) => List(x, y, z)).toList
     var payload = Map[String, Any]()
     payload += "points" -> out


### PR DESCRIPTION
Minor update to scatter3 chart support in lightning-scala:
- add label array in API with default value
- add size array in API with default value
- convert both into lists and add to data map being passed to internal plot call
