### PR TITLE
Add iframe/pym links and Fix authentication.

### DIFF
--- a/src/main/scala/org/viz/lightning/Lightning.scala
+++ b/src/main/scala/org/viz/lightning/Lightning.scala
@@ -61,20 +61,24 @@ class Lightning (var host: String) extends Plots with Three {
 
   def post(url: String, payload: String, method: String = "POST"): Int = {
 
-    val request = Http(url).postData(payload).method(method)
+    var request = Http(url).postData(payload).method(method)
       .header("content-type", "application/json")
       .header("accept", "text/plain")
 
     if (auth.nonEmpty) {
-      request.auth(auth.get._1, auth.get._2)
+      request = request.auth(auth.get._1, auth.get._2)
     }
 
     implicit val formats = DefaultFormats
 
     val response = request.asString
-    val json = parse(response.body)
-    (json \ "id").extract[Int]
-
+    response.body.toLowerCase match {
+      case "unauthorized" => throw new Exception("Unauthorized. Check username and/or password.")
+      case _ => {
+        val json = parse(response.body)
+        (json \ "id").extract[Int]
+      }
+    }
   }
 
   def postData(url: String, data: Map[String, Any], name: String, method: String = "POST"): Int = {

--- a/src/main/scala/org/viz/lightning/Visualization.scala
+++ b/src/main/scala/org/viz/lightning/Visualization.scala
@@ -22,6 +22,14 @@ class Visualization(lgn: Lightning, id: Int, name: String) {
     formatURL(this.getPermalinkURL + "/embed")
   }
 
+  def getIframeLink: String = {
+    formatURL(this.getPermalinkURL + "/iframe")
+  }
+
+  def getPymLink: String = {
+    formatURL(this.getPermalinkURL + "/pym")
+  }
+
   def getDataLink: String = {
     formatURL(lgn.host + "/sessions/" + lgn.session + "/visualizations/" + id + "/data/")
   }


### PR DESCRIPTION
Add iframe and pym links for Visualization.

Fix for HTTP basic authentication. 
- Add response check for error.
- change `val request` to `var request` and `request.auth()` to `request = request.auth()`
