### PR TITLE
add row and column labels to matrix plot

### DIFF
--- a/src/main/scala/org/viz/lightning/types/Plots.scala
+++ b/src/main/scala/org/viz/lightning/types/Plots.scala
@@ -101,9 +101,11 @@ trait Plots extends Base {
    * Dense matrix or a table as a heat map.
    */
   def matrix(matrix: Array[Array[Double]],
-             colormap: String = ""): Visualization = {
+             colormap: String = "",
+             rowLabels: Array[String] = Array[String](),
+             colLabels: Array[String] = Array[String]()): Visualization = {
 
-    val data = Map("matrix" -> matrix.toList)
+    val data = Map("matrix" -> matrix.toList, "rowLabels" -> rowLabels.toList,"columnLabels" -> colLabels.toList)
 
     val settings = new Settings()
       .append(Colormap(colormap))


### PR DESCRIPTION
Currently the client does not send column and row label information to the server for lighting-matrix visualization. This adds the `columnLabels` and `rowLabels` parameters to the matrix plot method signature and appends it to the JSON map.
