### PR TITLE
added labels to adjacency plot

### DIFF
--- a/src/main/scala/org/viz/lightning/types/Plots.scala
+++ b/src/main/scala/org/viz/lightning/types/Plots.scala
@@ -116,7 +116,7 @@ trait Plots extends Base {
    */
   def adjacency(conn: Array[Array[Double]],
                 label: Array[Int] = Array[Int](),
-                labels: Array[String]): Visualization = {
+                labels: Array[String] = Array[String]()): Visualization = {
 
     val links = Utils.getLinks(conn)
     val nodes = Utils.getNodes(conn)

--- a/src/main/scala/org/viz/lightning/types/Plots.scala
+++ b/src/main/scala/org/viz/lightning/types/Plots.scala
@@ -115,12 +115,13 @@ trait Plots extends Base {
    * Sparse adjacency matrix with labels from connectivity.
    */
   def adjacency(conn: Array[Array[Double]],
-                label: Array[Int] = Array[Int]()): Visualization = {
+                label: Array[Int] = Array[Int](),
+                labels: Array[String]): Visualization = {
 
     val links = Utils.getLinks(conn)
     val nodes = Utils.getNodes(conn)
 
-    val data = Map("links" -> links.toList, "nodes" -> nodes.toList)
+    val data = Map("links" -> links.toList, "nodes" -> nodes.toList, "labels" -> labels.toList)
 
     val settings = new Settings()
       .append(Label(label))


### PR DESCRIPTION
Currently the client does not send label information to the server for the lighting-adjacency visualization. This adds the `labels` parameter to the adjacency plot API.
