### PR TITLE
updated protocol to match new lightning server

### DIFF
--- a/src/main/scala/org/viz/lightning/Lightning.scala
+++ b/src/main/scala/org/viz/lightning/Lightning.scala
@@ -9,7 +9,7 @@ import scalaj.http._
 
 class Lightning (var host: String) extends Plots with Three with Linked {
 
-  var session: Int = -1
+  var session: String = ""
   var auth: Option[(String, String)] = None
   var isNotebook: Boolean = false
 
@@ -40,11 +40,11 @@ class Lightning (var host: String) extends Plots with Three with Linked {
 
     val id = postData(url, data, name)
 
-    new Visualization(this, id.toInt, name)
+    new Visualization(this, id, name)
 
   }
 
-  def useSession(id: Int): this.type = {
+  def useSession(id: String): this.type = {
     this.session = id
     this
   }
@@ -68,7 +68,7 @@ class Lightning (var host: String) extends Plots with Three with Linked {
     }
   }
 
-  def post(url: String, payload: String, method: String = "POST"): Int = {
+  def post(url: String, payload: String, method: String = "POST"): String = {
 
     var request = Http(url).postData(payload).method(method)
       .header("content-type", "application/json")
@@ -85,12 +85,12 @@ class Lightning (var host: String) extends Plots with Three with Linked {
       case "unauthorized" => throw new Exception("Unauthorized. Check username and/or password.")
       case _ => {
         val json = parse(response.body)
-        (json \ "id").extract[Int]
+        (json \ "id").extract[String]
       }
     }
   }
 
-  def postData(url: String, data: Map[String, Any], name: String, method: String = "POST"): Int = {
+  def postData(url: String, data: Map[String, Any], name: String, method: String = "POST"): String = {
 
     implicit val formats = DefaultFormats
 

--- a/src/main/scala/org/viz/lightning/Lightning.scala
+++ b/src/main/scala/org/viz/lightning/Lightning.scala
@@ -63,7 +63,7 @@ class Lightning (var host: String) extends Plots with Three with Linked {
   }
 
   def checkSession() {
-    if (session == -1) {
+    if (session == "") {
       this.createSession()
     }
   }

--- a/src/main/scala/org/viz/lightning/Visualization.scala
+++ b/src/main/scala/org/viz/lightning/Visualization.scala
@@ -5,7 +5,7 @@ import org.json4s.native.Serialization
 import scala.language.dynamics
 import scalaj.http._
 
-class Visualization(val lgn: Lightning, val id: Int, val name: String) {
+class Visualization(val lgn: Lightning, val id: String, val name: String) {
 
   if (lgn.isNotebook) {
     //implicit val HTMLViz = org.refptr.iscala.display.HTMLDisplay[Visualization] { viz =>

--- a/src/test/scala/org/viz/lightning/LightningSuite.scala
+++ b/src/test/scala/org/viz/lightning/LightningSuite.scala
@@ -7,7 +7,7 @@ class LightningSuite extends FunSuite {
   test("create session") {
     val lgn = Lightning("http://localhost:3000")
     lgn.createSession("test-session")
-    assert(lgn.session.isEmpty)
+    assert(!lgn.session.isEmpty)
   }
 
 }

--- a/src/test/scala/org/viz/lightning/LightningSuite.scala
+++ b/src/test/scala/org/viz/lightning/LightningSuite.scala
@@ -7,7 +7,7 @@ class LightningSuite extends FunSuite {
   test("create session") {
     val lgn = Lightning("http://localhost:3000")
     lgn.createSession("test-session")
-    assert(lgn.session > 0)
+    assert(lgn.session.isEmpty)
   }
 
 }


### PR DESCRIPTION
The old server was using ints for the session ids whereas the new one uses string hashes. This updates the client to adhere to the new server protocol.
