### PR TITLE
 Added method getPublicLink 

### DIFF
--- a/src/main/scala/org/viz/lightning/Visualization.scala
+++ b/src/main/scala/org/viz/lightning/Visualization.scala
@@ -58,5 +58,9 @@ class Visualization(val lgn: Lightning, val id: String, val name: String) {
     lgn.post(url, Serialization.write(blob))
     this
   }
-
+	
+  def getPublicLink: String = {
+    this.getPermalinkURL + "/public/"
+  }
+  
 }


### PR DESCRIPTION
To keep in consistent with python lightning-client and to test our visualizations added functionality to get the public link url 
